### PR TITLE
Infer log_path using $name (when log_path is unset)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ spec/fixtures/
 coverage/
 *.iml
 .idea/
+*.sw[pno]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ The purpose of this module is to manage each of the Windows event logs, includin
     }
 ```
 
+  Manage several custom logs under C:\Logs:
+
+```puppet
+   windows_eventlog { ['Custom1', 'Custom2', 'Custom3']:
+     log_path_template => 'C:\Logs\%%NAME%%.evtx'
+   }
+```
 ##Usage
 
 ###Classes and Defined Types:
@@ -50,13 +57,16 @@ The primary definition of this module. Manages the size and rotation policy of W
 
 **Parameters within `windows_eventlog`:**
 #####`log_path`
-The path to the log file that you want to manage
+_(Optional)_ The path to the log file that you want to manage.
 
 #####`log_size`
-The max size of the log file
+The max size of the log file.  Defaults to '`1028`'.
 
 #####`max_log_policy`
-The retention policy for the log
+The retention policy for the log.  Defaults to '`overwrite`'.
+
+##### `log_path_template`
+_(Optional)_ A template for `log_path`, where "`%%NAME%%`" will be replaced with the log name.  Defaults to '`%SystemRoot%\\system32\\winevt\\Logs\\%%NAME%%.evtx`'.
 
 ##Reference
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,9 @@
 # [*max_log_policy*]
 # The retention policy for the log
 #
+# [*log_path_template*]
+# A template for log_path, where "%%NAME%%" will be replaced with the log name
+#
 # === Examples
 #
 # Manage the size of the Application log:
@@ -32,15 +35,29 @@
 #     max_log_policy => 'overwrite'
 #   }
 #
+#
+# Manage several custom event logs under C:\Logs:
+#
+#   windows_eventlog { ['Custom1', 'Custom2', 'Custom3']:
+#     log_path_template => 'C:\Logs\%%NAME%%.evtx'
+#   }
+#
+#
 define windows_eventlog(
-  $log_path,
-  $log_size = '1028',
-  $max_log_policy = 'overwrite'
+  $log_path          = undef,
+  $log_size          = '1028',
+  $max_log_policy    = 'overwrite',
+  $log_path_template = "%SystemRoot%\\system32\\winevt\\Logs\\%%NAME%%.evtx"
 ){
+  $l_log_path = $log_path? {
+    undef   => regsubst( $log_path_template, '%%NAME%%', $name ),
+    default => $log_path,
+  }
 
-  validate_string($log_path)
+  validate_string($l_log_path)
   validate_re($log_size, '^\d*$','The log_size argument must be a number or a string representation of a number')
   validate_re($max_log_policy, '^(overwrite|manual|archive)$','The max_log_policy argument must contain overwrite, manual or archive')
+  validate_re($log_path_template, '%%NAME%%','The log_path_template must contain the string "%%NAME%%"')
 
   $root_key = 'HKLM\System\CurrentControlSet\Services\Eventlog'
 
@@ -51,7 +68,7 @@ define windows_eventlog(
   registry_value { "${root_key}\\${name}\\File":
     ensure => present,
     type   => 'expand',
-    data   => $log_path
+    data   => $l_log_path
   }
 
   registry_value { "${root_key}\\${name}\\MaxSize":

--- a/metadata.json
+++ b/metadata.json
@@ -1,16 +1,21 @@
 {
-  "name":         "puppet-windows_eventlog",
-  "version":      "1.0.0",
-  "author":       "puppetcommunity",
-  "license":      "Apache 2.0",
-  "summary":      "Module for managing the windows event log",
-  "source":       "https://github.com/puppet-community/puppet-windows_eventlog",
+  "name": "puppet-windows_eventlog",
+  "version": "1.1.0",
+  "author": "puppetcommunity",
+  "license": "Apache 2.0",
+  "summary": "Module for managing the windows event log",
+  "source": "https://github.com/puppet-community/puppet-windows_eventlog",
   "project_page": "https://github.com/puppet-community/puppet-windows_eventlog",
-  "issues_url":   "https://github.com/puppet-community/puppet-windows_eventlog/issues",
+  "issues_url": "https://github.com/puppet-community/puppet-windows_eventlog/issues",
   "operatingsystem_support": [
     {
       "operatingsystem": "windows",
-      "operatingsystemrelease": ["2008","2008 R2", "2012", "2012 R2"]
+      "operatingsystemrelease": [
+        "2008",
+        "2008 R2",
+        "2012",
+        "2012 R2"
+      ]
     }
   ],
   "dependencies": [

--- a/spec/defines/windows_eventlog/windows_eventlog_spec.rb
+++ b/spec/defines/windows_eventlog/windows_eventlog_spec.rb
@@ -102,4 +102,34 @@ describe 'windows_eventlog', :type => :define do
       'data'   => '2222'
     )}
   end
+
+  describe 'log without a log_path' do
+    let :title do 'Something' end
+    let :params do
+      { :log_size => '1028', :max_log_policy => 'overwrite' }
+    end
+
+    it 'should infer the log_path using $name' do
+        should contain_registry_value('HKLM\System\CurrentControlSet\Services\Eventlog\Something\File').with(
+        'ensure' => 'present',
+        'type'   => 'expand',
+        'data'   => '%SystemRoot%\system32\winevt\Logs\Something.evtx'
+      )
+    end
+  end
+
+  describe 'log with a custom log_path_template and without log_path' do
+    let :title do 'Custom1' end
+    let :params do
+      { :log_size => '1028', :max_log_policy => 'overwrite', 'log_path_template' => 'C:\Logs\%%NAME%%' }
+    end
+
+    it 'should infer the log_path using $log_path_template and $name' do
+        should contain_registry_value('HKLM\System\CurrentControlSet\Services\Eventlog\Custom1\File').with(
+        'ensure' => 'present',
+        'type'   => 'expand',
+        'data'   => 'C:\Logs\Custom1'
+      )
+    end
+  end
 end


### PR DESCRIPTION
This patch makes the log_path parameter optional.  When log_path is not
specified, its value is inferred using the value of $name and a new
optional parameter, default_log_path.

The update adds functionality in a backwards-compatible manner, so the
version in metadata.json has been bumped from 1.0.0 to 1.1.0.